### PR TITLE
[Donut Chart] [Customization] Add label when no slice is selected and enable/disable click on slice

### DIFF
--- a/YChartsLib/src/androidTest/java/co/yml/charts/piechart/DonutPieChartTest.kt
+++ b/YChartsLib/src/androidTest/java/co/yml/charts/piechart/DonutPieChartTest.kt
@@ -23,9 +23,9 @@ class DonutPieChartTest {
     val composeTestRule = createComposeRule()
 
     private val pieChartConfig = PieChartConfig(
-        percentVisible = false,
+        labelVisible = false,
         strokeWidth = 120f,
-        percentColor = Color.Black
+        labelColor = Color.Black
     )
 
     private val pieChartData = PieChartData(
@@ -70,4 +70,3 @@ class DonutPieChartTest {
         composeTestRule.onNodeWithText("C").assertDoesNotExist()
     }
 }
-

--- a/YChartsLib/src/androidTest/java/co/yml/charts/piechart/PieChartTest.kt
+++ b/YChartsLib/src/androidTest/java/co/yml/charts/piechart/PieChartTest.kt
@@ -21,9 +21,9 @@ class PieChartTest {
     val composeTestRule = createComposeRule()
 
     private val pieChartConfig = PieChartConfig(
-        percentVisible = false,
+        labelVisible = false,
         strokeWidth = 120f,
-        percentColor = Color.Black
+        labelColor = Color.Black
     )
     private val pieChartData = PieChartData(
         slices = listOf(

--- a/YChartsLib/src/main/java/co/yml/charts/ui/piechart/PieChartConstants.kt
+++ b/YChartsLib/src/main/java/co/yml/charts/ui/piechart/PieChartConstants.kt
@@ -10,4 +10,5 @@ object PieChartConstants {
     const val TOTAL_ANGLE = 360
     const val ONE_HUNDRED = 100
     const val DESCRIPTION = "Double tap to know the chart in detail"
+    const val NO_SELECTED_SLICE = -1
 }

--- a/YChartsLib/src/main/java/co/yml/charts/ui/piechart/charts/DonutPieChart.kt
+++ b/YChartsLib/src/main/java/co/yml/charts/ui/piechart/charts/DonutPieChart.kt
@@ -5,6 +5,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
@@ -92,6 +93,7 @@ fun DonutPieChart(
         val boxModifier = if (pieChartConfig.isClickOnSliceEnabled) {
             modifier
                 .aspectRatio(1f)
+                .background(pieChartConfig.backgroundColor)
                 .semantics {
                     contentDescription = pieChartConfig.accessibilityConfig.chartDescription
                 }

--- a/YChartsLib/src/main/java/co/yml/charts/ui/piechart/charts/DonutPieChart.kt
+++ b/YChartsLib/src/main/java/co/yml/charts/ui/piechart/charts/DonutPieChart.kt
@@ -31,6 +31,7 @@ import co.yml.charts.common.components.accessibility.AccessibilityBottomSheetDia
 import co.yml.charts.common.components.accessibility.SliceInfo
 import co.yml.charts.common.extensions.collectIsTalkbackEnabledAsState
 import co.yml.charts.common.model.PlotType
+import co.yml.charts.ui.piechart.PieChartConstants.NO_SELECTED_SLICE
 import co.yml.charts.ui.piechart.models.PieChartConfig
 import co.yml.charts.ui.piechart.models.PieChartData
 import co.yml.charts.ui.piechart.utils.convertTouchEventPointToAngle
@@ -38,7 +39,6 @@ import co.yml.charts.ui.piechart.utils.proportion
 import co.yml.charts.ui.piechart.utils.sweepAngles
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
-
 
 /**
  * Compose function for Drawing Donut chart
@@ -72,7 +72,7 @@ fun DonutPieChart(
     }
 
     var activePie by rememberSaveable {
-        mutableStateOf(-1)
+        mutableStateOf(NO_SELECTED_SLICE)
     }
     val accessibilitySheetState =
         rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
@@ -92,7 +92,7 @@ fun DonutPieChart(
     ) {
         val boxModifier = if (pieChartConfig.isClickOnSliceEnabled) {
             modifier
-                .aspectRatio(1f)
+                .aspectRatio(ratio = 1f)
                 .background(pieChartConfig.backgroundColor)
                 .semantics {
                     contentDescription = pieChartConfig.accessibilityConfig.chartDescription
@@ -148,7 +148,7 @@ fun DonutPieChart(
                                     activePie = if (activePie != index)
                                         index
                                     else
-                                        -1
+                                        NO_SELECTED_SLICE
                                     onSliceClick(pieChartData.slices[index])
                                     return@detectTapGestures
                                 }

--- a/YChartsLib/src/main/java/co/yml/charts/ui/piechart/charts/PieChart.kt
+++ b/YChartsLib/src/main/java/co/yml/charts/ui/piechart/charts/PieChart.kt
@@ -209,7 +209,7 @@ fun PieChart(
                             it.nativeCanvas.withRotation(
                                 arcCenter, x, y
                             ) {
-                                if (pieChartConfig.percentVisible) {
+                                if (pieChartConfig.labelVisible) {
                                     label = "$label ${proportions[index].roundToInt()}%"
                                 }
                                 it.nativeCanvas.drawText(

--- a/YChartsLib/src/main/java/co/yml/charts/ui/piechart/charts/PieChart.kt
+++ b/YChartsLib/src/main/java/co/yml/charts/ui/piechart/charts/PieChart.kt
@@ -38,6 +38,7 @@ import co.yml.charts.common.extensions.collectIsTalkbackEnabledAsState
 import co.yml.charts.common.extensions.getTextHeight
 import co.yml.charts.common.model.PlotType
 import co.yml.charts.ui.piechart.PieChartConstants.MINIMUM_PERCENTAGE_FOR_SLICE_LABELS
+import co.yml.charts.ui.piechart.PieChartConstants.NO_SELECTED_SLICE
 import co.yml.charts.ui.piechart.models.PieChartConfig
 import co.yml.charts.ui.piechart.models.PieChartData
 import co.yml.charts.ui.piechart.utils.convertTouchEventPointToAngle
@@ -80,7 +81,7 @@ fun PieChart(
     }
 
     var activePie by rememberSaveable {
-        mutableStateOf(-1)
+        mutableStateOf(NO_SELECTED_SLICE)
     }
     val accessibilitySheetState =
         rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
@@ -98,7 +99,7 @@ fun PieChart(
     ) {
         val boxModifier = if (pieChartConfig.isClickOnSliceEnabled) {
             modifier
-                .aspectRatio(1f)
+                .aspectRatio(ratio = 1f)
                 .background(pieChartConfig.backgroundColor)
                 .semantics {
                     contentDescription = pieChartConfig.accessibilityConfig.chartDescription
@@ -152,7 +153,7 @@ fun PieChart(
                                     activePie = if (activePie != index)
                                         index
                                     else
-                                        -1
+                                        NO_SELECTED_SLICE
                                     onSliceClick(pieChartData.slices[index])
                                     return@detectTapGestures
                                 }

--- a/YChartsLib/src/main/java/co/yml/charts/ui/piechart/models/PieChartConfig.kt
+++ b/YChartsLib/src/main/java/co/yml/charts/ui/piechart/models/PieChartConfig.kt
@@ -25,10 +25,12 @@ import co.yml.charts.ui.piechart.PieChartConstants.DEFAULT_STROKE_WIDTH
  * @param isAnimationEnable: Boolean Flag for enabling animation
  * @param animationDuration: Duration of animation
  * @param strokeWidth: Stroke width of Donut Chart
- * @param percentageFontSize: Percentage text font size
- * @param percentageTypeface: Percentage text typeface
- * @param percentVisible: Percentage text visibility
- * @param percentColor: Percentage text color
+ * @param labelFontSize: Label text font size
+ * @param labelTypeface: Label text typeface
+ * @param labelVisible: Label text visibility
+ * @param labelType: Type of label (percentage or value of slice), value available only for Donut Chart
+ * @param labelColor: Label text color
+ * @param labelColorType: Label text color according to the specified in color in labelColor or the slice color, only for Donut Chart
  * @param activeSliceAlpha: Opacity of the active slice
  * @param inActiveSliceAlpha: Opacity of the inactive slice
  * @param isEllipsizeEnabled: Boolean flag for enabling ellipsize
@@ -36,9 +38,9 @@ import co.yml.charts.ui.piechart.PieChartConstants.DEFAULT_STROKE_WIDTH
  * @param sliceLabelEllipsizeAt: Position at which the label will be truncated or ellipsized
  * @param chartPadding: Padding for the Pie chart/Donut Chart
  * @param accessibilityConfig: Configs related to accessibility service defined here in [AccessibilityConfig]
- * @param isSumVisible: When no slice is selected show the sum of values
+ * @param isSumVisible: When no slice is selected show the sum of values, only used for Donut Chart
  * @param isClickOnSliceEnabled: Enable/Disable the click on slice
- * @param sumUnit: The unit of the sum of values
+ * @param sumUnit: The unit of the sum of values, only used for Donut Chart
  */
 data class PieChartConfig(
     val startAngle: Float = DEFAULT_START_ANGLE,
@@ -49,10 +51,12 @@ data class PieChartConfig(
     val isAnimationEnable: Boolean = false,
     @IntRange(from = 1) val animationDuration: Int = 500,
     val strokeWidth: Float = DEFAULT_STROKE_WIDTH,
-    val percentageFontSize: TextUnit = 24.sp,
-    val percentageTypeface: Typeface = Typeface.DEFAULT,
-    val percentVisible: Boolean = false,
-    val percentColor: Color = Color.White,
+    val labelFontSize: TextUnit = 24.sp,
+    val labelTypeface: Typeface = Typeface.DEFAULT,
+    val labelVisible: Boolean = false,
+    val labelType: LabelType = LabelType.PERCENTAGE,
+    val labelColor: Color = Color.White,
+    val labelColorType: LabelColorType = LabelColorType.SPECIFIED_COLOR,
     val activeSliceAlpha: Float = .8f,
     val inActiveSliceAlpha: Float = 1f,
     val isEllipsizeEnabled: Boolean = false,
@@ -65,4 +69,14 @@ data class PieChartConfig(
     val isSumVisible: Boolean = false,
     val sumUnit: String = "",
     val isClickOnSliceEnabled: Boolean = true
-)
+){
+    enum class LabelType {
+        PERCENTAGE,
+        VALUE
+    }
+
+    enum class LabelColorType {
+        SPECIFIED_COLOR,
+        SLICE_COLOR
+    }
+}

--- a/YChartsLib/src/main/java/co/yml/charts/ui/piechart/models/PieChartConfig.kt
+++ b/YChartsLib/src/main/java/co/yml/charts/ui/piechart/models/PieChartConfig.kt
@@ -8,12 +8,12 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import co.yml.charts.common.model.AccessibilityConfig
 import co.yml.charts.ui.piechart.PieChartConstants
 import co.yml.charts.ui.piechart.PieChartConstants.DEFAULT_PADDING
 import co.yml.charts.ui.piechart.PieChartConstants.DEFAULT_SLICE_LABEL_TEXT_SIZE
 import co.yml.charts.ui.piechart.PieChartConstants.DEFAULT_START_ANGLE
 import co.yml.charts.ui.piechart.PieChartConstants.DEFAULT_STROKE_WIDTH
-import co.yml.charts.common.model.AccessibilityConfig
 
 /**
  * PieChartConfig data class used to mention all config related param required to draw PieChart.
@@ -36,6 +36,9 @@ import co.yml.charts.common.model.AccessibilityConfig
  * @param sliceLabelEllipsizeAt: Position at which the label will be truncated or ellipsized
  * @param chartPadding: Padding for the Pie chart/Donut Chart
  * @param accessibilityConfig: Configs related to accessibility service defined here in [AccessibilityConfig]
+ * @param isSumVisible: When no slice is selected show the sum of values
+ * @param isClickOnSliceEnabled: Enable/Disable the click on slice
+ * @param sumUnit: The unit of the sum of values
  */
 data class PieChartConfig(
     val startAngle: Float = DEFAULT_START_ANGLE,
@@ -58,5 +61,8 @@ data class PieChartConfig(
     val chartPadding: Int = DEFAULT_PADDING,
     val accessibilityConfig: AccessibilityConfig = AccessibilityConfig(
         chartDescription = PieChartConstants.DESCRIPTION
-    )
+    ),
+    val isSumVisible: Boolean = false,
+    val sumUnit: String = "",
+    val isClickOnSliceEnabled: Boolean = true
 )

--- a/YChartsLib/src/main/java/co/yml/charts/ui/piechart/models/PieChartConfig.kt
+++ b/YChartsLib/src/main/java/co/yml/charts/ui/piechart/models/PieChartConfig.kt
@@ -57,6 +57,7 @@ data class PieChartConfig(
     val labelType: LabelType = LabelType.PERCENTAGE,
     val labelColor: Color = Color.White,
     val labelColorType: LabelColorType = LabelColorType.SPECIFIED_COLOR,
+    val backgroundColor: Color = Color.White,
     val activeSliceAlpha: Float = .8f,
     val inActiveSliceAlpha: Float = 1f,
     val isEllipsizeEnabled: Boolean = false,

--- a/app/src/main/java/co/yml/ycharts/app/presentation/DonutChartActivity.kt
+++ b/app/src/main/java/co/yml/ycharts/app/presentation/DonutChartActivity.kt
@@ -16,11 +16,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import co.yml.charts.common.components.Legends
+import co.yml.charts.common.utils.DataUtils
 import co.yml.charts.ui.piechart.charts.DonutPieChart
 import co.yml.charts.ui.piechart.models.PieChartConfig
 import co.yml.charts.ui.piechart.utils.proportion
-import co.yml.charts.common.components.Legends
-import co.yml.charts.common.utils.DataUtils
 import co.yml.ycharts.app.R
 import co.yml.ycharts.app.ui.compositions.AppBarWithBackButton
 import co.yml.ycharts.app.ui.theme.YChartsTheme
@@ -79,7 +79,9 @@ private fun DonutChart1(context: Context) {
             percentageTypeface = Typeface.defaultFromStyle(Typeface.BOLD),
             isAnimationEnable = true,
             chartPadding = 25,
-            percentageFontSize = 42.sp
+            percentageFontSize = 42.sp,
+            isSumVisible = true,
+            sumUnit = "Unit"
         )
     Column {
         Legends(legendsConfig = DataUtils.getLegendsConfigFromPieChartData(pieChartData = data, 3))

--- a/app/src/main/java/co/yml/ycharts/app/presentation/DonutChartActivity.kt
+++ b/app/src/main/java/co/yml/ycharts/app/presentation/DonutChartActivity.kt
@@ -157,42 +157,46 @@ private fun MultipleSmallDonutCharts(context: Context) {
     val proportions = data.slices.proportion(sumOfValues)
     val firstPieChartConfig =
         PieChartConfig(
-            percentVisible = true,
+            labelVisible = true,
             strokeWidth = 50f,
-            percentColor = Color.Black,
+            labelColor = Color.Black,
             backgroundColor = Color.Yellow,
             activeSliceAlpha = .9f,
             isEllipsizeEnabled = true,
-            percentageTypeface = Typeface.defaultFromStyle(Typeface.BOLD),
+            labelTypeface = Typeface.defaultFromStyle(Typeface.BOLD),
             isAnimationEnable = true,
             chartPadding = 25,
-            percentageFontSize = 16.sp
+            labelFontSize = 16.sp
         )
     val secondPieChartConfig =
         PieChartConfig(
-            percentVisible = true,
+            labelVisible = true,
             strokeWidth = 50f,
-            percentColor = Color.White,
-            backgroundColor = Color.Black,
+            labelColor = Color.Black,
             activeSliceAlpha = .9f,
             isEllipsizeEnabled = true,
-            percentageTypeface = Typeface.defaultFromStyle(Typeface.BOLD),
+            backgroundColor = Color.Black,
+            labelTypeface = Typeface.defaultFromStyle(Typeface.BOLD),
             isAnimationEnable = true,
             chartPadding = 25,
-            percentageFontSize = 16.sp
+            labelFontSize = 16.sp,
+            isSumVisible = true,
+            sumUnit = "unit",
+            labelColorType = PieChartConfig.LabelColorType.SLICE_COLOR,
+            labelType = PieChartConfig.LabelType.VALUE
         )
     val thirdPieChartConfig =
         PieChartConfig(
-            percentVisible = true,
+            labelVisible = true,
             strokeWidth = 50f,
-            percentColor = Color.Black,
+            labelColor = Color.Black,
             activeSliceAlpha = .9f,
             backgroundColor = Color.LightGray,
             isEllipsizeEnabled = true,
-            percentageTypeface = Typeface.defaultFromStyle(Typeface.BOLD),
+            labelTypeface = Typeface.defaultFromStyle(Typeface.BOLD),
             isAnimationEnable = true,
             chartPadding = 25,
-            percentageFontSize = 16.sp
+            labelFontSize = 16.sp
         )
     Column(
         modifier = Modifier

--- a/app/src/main/java/co/yml/ycharts/app/presentation/DonutChartActivity.kt
+++ b/app/src/main/java/co/yml/ycharts/app/presentation/DonutChartActivity.kt
@@ -7,6 +7,7 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
@@ -45,11 +46,17 @@ class DonutChartActivity : ComponentActivity() {
                     val context = LocalContext.current
                     Box(
                         modifier = Modifier
-                            .padding(it)
                             .fillMaxSize()
+                            .padding(it)
                     ) {
-                        Spacer(modifier = Modifier.height(20.dp))
-                        DonutChart1(context)
+                        LazyColumn{
+                            items(count = 3){ item ->
+                                when (item){
+                                    0 -> DonutChart1(context)
+                                    1 -> DonutChart2(context)
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -71,24 +78,64 @@ private fun DonutChart1(context: Context) {
     val proportions = data.slices.proportion(sumOfValues)
     val pieChartConfig =
         PieChartConfig(
-            percentVisible = true,
+            labelVisible = true,
             strokeWidth = 120f,
-            percentColor = Color.Black,
+            labelColor = Color.Black,
             activeSliceAlpha = .9f,
             isEllipsizeEnabled = true,
-            percentageTypeface = Typeface.defaultFromStyle(Typeface.BOLD),
+            labelTypeface = Typeface.defaultFromStyle(Typeface.BOLD),
             isAnimationEnable = true,
             chartPadding = 25,
-            percentageFontSize = 42.sp,
-            isSumVisible = true,
-            sumUnit = "Unit"
+            labelFontSize = 42.sp,
         )
-    Column {
+    Column(modifier = Modifier.height(500.dp)) {
         Legends(legendsConfig = DataUtils.getLegendsConfigFromPieChartData(pieChartData = data, 3))
         DonutPieChart(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(500.dp),
+                .height(400.dp),
+            data,
+            pieChartConfig
+        ) { slice ->
+            Toast.makeText(context, slice.label, Toast.LENGTH_SHORT).show()
+        }
+    }
+}
+
+@ExperimentalMaterialApi
+@Composable
+private fun DonutChart2(context: Context) {
+    val accessibilitySheetState =
+        rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
+    val scope = rememberCoroutineScope()
+    val data = DataUtils.getDonutChartData()
+    // Sum of all the values
+    val sumOfValues = data.totalLength
+
+    // Calculate each proportion value
+    val proportions = data.slices.proportion(sumOfValues)
+    val pieChartConfig =
+        PieChartConfig(
+            labelVisible = true,
+            strokeWidth = 120f,
+            labelColor = Color.Black,
+            activeSliceAlpha = .9f,
+            isEllipsizeEnabled = true,
+            labelTypeface = Typeface.defaultFromStyle(Typeface.BOLD),
+            isAnimationEnable = true,
+            chartPadding = 25,
+            labelFontSize = 42.sp,
+            isSumVisible = true,
+            sumUnit = "",
+            labelColorType = PieChartConfig.LabelColorType.SLICE_COLOR,
+            labelType = PieChartConfig.LabelType.VALUE
+        )
+    Column(modifier = Modifier.height(500.dp)) {
+        Legends(legendsConfig = DataUtils.getLegendsConfigFromPieChartData(pieChartData = data, 3))
+        DonutPieChart(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(400.dp),
             data,
             pieChartConfig
         ) { slice ->

--- a/app/src/main/java/co/yml/ycharts/app/presentation/PieChartActivity.kt
+++ b/app/src/main/java/co/yml/ycharts/app/presentation/PieChartActivity.kt
@@ -16,10 +16,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import co.yml.charts.ui.piechart.charts.PieChart
-import co.yml.charts.ui.piechart.models.PieChartConfig
 import co.yml.charts.common.components.Legends
 import co.yml.charts.common.utils.DataUtils
+import co.yml.charts.ui.piechart.charts.PieChart
+import co.yml.charts.ui.piechart.models.PieChartConfig
 import co.yml.ycharts.app.R
 import co.yml.ycharts.app.ui.compositions.AppBarWithBackButton
 import co.yml.ycharts.app.ui.theme.YChartsTheme
@@ -65,7 +65,7 @@ private fun PieChart1(context: Context) {
     val pieChartData = DataUtils.getPieChartData()
     val pieChartConfig =
         PieChartConfig(
-            percentVisible = true,
+            labelVisible = true,
             activeSliceAlpha = .9f,
             isEllipsizeEnabled = true,
             sliceLabelEllipsizeAt = TextUtils.TruncateAt.MIDDLE,
@@ -103,7 +103,7 @@ private fun PieChart2(context: Context) {
             isAnimationEnable = true,
             chartPadding = 20,
             showSliceLabels = true,
-            percentVisible = true
+            labelVisible = true
         )
     Column(modifier = Modifier.height(500.dp)) {
         Legends(legendsConfig = DataUtils.getLegendsConfigFromPieChartData(pieChartData, 3))
@@ -118,4 +118,3 @@ private fun PieChart2(context: Context) {
         }
     }
 }
-

--- a/experiments/piechartcontainer/src/main/java/com/example/piechartcontainer/ChartContainer.kt
+++ b/experiments/piechartcontainer/src/main/java/com/example/piechartcontainer/ChartContainer.kt
@@ -7,10 +7,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import co.yml.charts.common.model.PlotType
 import co.yml.charts.ui.piechart.ChartWrapper.DrawChart
 import co.yml.charts.ui.piechart.models.PieChartConfig
 import co.yml.charts.ui.piechart.models.PieChartData
-import co.yml.charts.common.model.PlotType
 
 @Composable
 fun ChartContainer() {
@@ -27,9 +27,9 @@ fun ChartContainer() {
 
         val pieChartConfig =
             PieChartConfig(
-                percentVisible = true,
+                labelVisible = true,
                 strokeWidth = 120f,
-                percentColor = Color.Black
+                labelColor = Color.Black
             )
 
 

--- a/experiments/piechartcontainer/src/main/java/com/example/piechartcontainer/PieChartActivity.kt
+++ b/experiments/piechartcontainer/src/main/java/com/example/piechartcontainer/PieChartActivity.kt
@@ -16,12 +16,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import co.yml.charts.ui.piechart.charts.PieChart
-import co.yml.charts.ui.piechart.models.PieChartConfig
-import co.yml.charts.ui.piechart.models.PieChartData
 import co.yml.charts.common.components.Legends
 import co.yml.charts.common.model.PlotType
 import co.yml.charts.common.utils.DataUtils
+import co.yml.charts.ui.piechart.charts.PieChart
+import co.yml.charts.ui.piechart.models.PieChartConfig
+import co.yml.charts.ui.piechart.models.PieChartData
 import com.example.piechartcontainer.ui.theme.YChartsTheme
 
 class PieChartActivity : ComponentActivity() {
@@ -50,13 +50,13 @@ class PieChartActivity : ComponentActivity() {
 
                     val pieChartConfig =
                         PieChartConfig(
-                            percentVisible = true,
+                            labelVisible = true,
                             strokeWidth = 120f,
-                            percentColor = Color.Black,
+                            labelColor = Color.Black,
                             activeSliceAlpha = .9f,
                             isEllipsizeEnabled = true,
                             sliceLabelEllipsizeAt = TextUtils.TruncateAt.MIDDLE,
-                            percentageTypeface = Typeface.defaultFromStyle(Typeface.BOLD),
+                            labelTypeface = Typeface.defaultFromStyle(Typeface.BOLD),
                             isAnimationEnable = true,
                             showSliceLabels = true,
                             chartPadding = 25,


### PR DESCRIPTION
Hi guys!

First of all, thanks for the awesome work! I'm a fan. :fire: :heart_eyes: 
I would like to add a few customizations to the donut/pie chart.

Display the sum of values with a unit on 2 lines (to avoid the line becomes too big and overlap the chart)
Enable/disable the click on slice.

Those customizations don't affect the original looking of the chart since they can be disabled/enabled (and are disabled by default).

According with those 2 features, it is now possible to come back to a no_selection case.

I find those customizations very useful.

Feel free to comment, suggest any suggestion to my PR :smile: 

Again, thanks for the work!

EDIT:
I've added a few more customizations:

Display percentage OR value of slice with unit (percentage by default)

Label color can match slice color (specified color by default)

Here is a video: showing firstly the chart without my customizations then with my customizations. I don't show the no click feature, I can add one more video for that if wanted.

https://user-images.githubusercontent.com/27420929/231124831-91bfed1b-f071-42b2-a874-971144e33109.mp4

