### PR TITLE
Set antiAliasing to true for DonutPieChart

### DIFF
--- a/YChartsLib/src/main/java/co/yml/charts/ui/piechart/charts/DonutPieChart.kt
+++ b/YChartsLib/src/main/java/co/yml/charts/ui/piechart/charts/DonutPieChart.kt
@@ -8,14 +8,24 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Surface
 import androidx.compose.material.rememberModalBottomSheetState
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
@@ -266,6 +276,7 @@ private fun drawLabel(
     sideSize: Int
 ) {
     val paint = Paint().apply {
+        isAntiAlias = true
         color = labelColor.toArgb()
         textSize = fontSize
         textAlign = Paint.Align.CENTER


### PR DESCRIPTION
Hi guys!

On some devices the `label` for the `DonutPieChart` is pixelated  
![image](https://user-images.githubusercontent.com/27420929/233321015-f9207325-10a5-422a-a002-f27996ec42a8.png)

So I set the `isAntiAlias` `Painter` property to true. I saw it was already done in some other charts such as `PieChart` one.

here the result:
![image](https://user-images.githubusercontent.com/27420929/233321283-e552aa25-3e3e-4ebf-9aa7-61814e675635.png)
