### PR TITLE
Advanced Cubic Bezier algorithm for prettier line charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
 # YCharts
+This is a fork the YCharts library using Advanced Cubic Bezier algorithm for prettier line charts.
+The algorithm is explained in detail at [https://medium.com/mobile-app-development-publication/making-graph-plotting-function-in-jetpack-compose-95c80ee6fc7f](https://medium.com/mobile-app-development-publication/making-graph-plotting-function-in-jetpack-compose-95c80ee6fc7f)
+    <div>
+    <figure>
+      <img width=100 src="https://github.com/codeandtheory/YCharts/assets/6216877/f9bf3760-ca16-4644-8abc-b1326d28b8d3"/>
+    </figure>
+    </div>
+    Advanced Cubic Bezier
+    <div>
+    <figure>
+      <img width=100 src="https://github.com/codeandtheory/YCharts/assets/6216877/12a086eb-3fe0-43e2-b9ed-2e1dafbab8ad"/>
+    </figure>
+    </div>
+    Basic Cubic Bezier
 
 YCharts is a Jetpack-compose based  charts library which enables developers to easily integrate various types of charts/graphs into their existing ui to visually represent statistical data. YCharts supports both cartesian(XY-charts)  and polar charts(Radial charts), which include:
 

--- a/YChartsLib/build.gradle.kts
+++ b/YChartsLib/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 35
     namespace = "co.yml.charts.components"
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/YChartsLib/build.gradle.kts
+++ b/YChartsLib/build.gradle.kts
@@ -5,11 +5,12 @@ plugins {
     id("ycharts.android.test")
     id("maven-publish")
     id("signing")
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.0"
     alias(versionCatalogLibs.plugins.dokka)
 }
 
 android {
-    compileSdk = 35
+    compileSdk = 36
     namespace = "co.yml.charts.components"
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -21,6 +22,13 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+        }
+    }
+    publishing {
+        singleVariant("release") {
+            // You can add specific configurations for the 'release' variant here if needed.
+            // For example, to specify components to publish:
+            // from(components.release)
         }
     }
 }

--- a/YChartsLib/src/main/java/co/yml/charts/ui/linechart/LineChart.kt
+++ b/YChartsLib/src/main/java/co/yml/charts/ui/linechart/LineChart.kt
@@ -468,17 +468,23 @@ fun getCubicPoints(pointsData: List<Offset>): Pair<MutableList<Offset>, MutableL
     val cubicPoints1 = mutableListOf<Offset>()
     val cubicPoints2 = mutableListOf<Offset>()
 
-    val slopes = FloatArray(pointsData.size+1)
+    val slopes = FloatArray(pointsData.size)
 
     for (i in 1 until pointsData.size) {
         val currSlope = if (i == 1)  getSlope(pointsData[1], pointsData[0]) else slopes [i]
 
-        val nextSlope = if (i < pointsData.size-1) getSlope (pointsData[i+1], pointsData[i]) else currSlope
-        slopes[i+1] = nextSlope
+        val nextSlope: Float
+        if (i < pointsData.size-1) {
+            nextSlope = getSlope(pointsData[i + 1], pointsData[i])
+            slopes[i+1] = nextSlope
+        }
+        else  {
+            nextSlope = currSlope
+        }
 
         val prevSlope = if (i >1 )  slopes[i-1] else currSlope
 
-        val cp1x = ( (pointsData[i-1].x * 2f) + pointsData[i].x)/3f
+        val cp1x = ((pointsData[i-1].x * 2f) + pointsData[i].x)/3f
         val cp1slope = getInBetweenSlope(prevSlope, currSlope)
         val cp1c = pointsData[i-1].y - (cp1slope * pointsData[i-1].x)
         val cp1y = (cp1slope * cp1x) + cp1c

--- a/YChartsLib/src/main/java/co/yml/charts/ui/linechart/LineChart.kt
+++ b/YChartsLib/src/main/java/co/yml/charts/ui/linechart/LineChart.kt
@@ -59,7 +59,7 @@ import co.yml.charts.ui.linechart.model.LineType
 import co.yml.charts.ui.linechart.model.SelectionHighlightPoint
 import co.yml.charts.ui.linechart.model.SelectionHighlightPopUp
 import kotlinx.coroutines.launch
-import kotlin.math.pow
+import kotlin.math.sqrt
 
 /**
  *
@@ -452,7 +452,7 @@ fun DrawScope.drawShadowUnderLineAndIntersectionPoint(
 }
 
 private fun getInBetweenSlope(m1: Float, m2: Float) : Float {
-    return if (m1 == m2)  m1 else  (m1 + m2) / ( 1 - m1 * m2  + ((m1.pow(2)+1) * (m2.pow(2) + 1)).pow(0.5f) )
+    return if (m1 == m2)  m1 else  (m1 + m2) / ( 1 - m1 * m2  + sqrt(((m1*m1) + 1) * ((m2*m2) + 1)) )
 }
 
 private fun getSlope(p1: Offset, p2: Offset): Float {

--- a/YChartsLib/src/main/java/co/yml/charts/ui/linechart/LineChart.kt
+++ b/YChartsLib/src/main/java/co/yml/charts/ui/linechart/LineChart.kt
@@ -59,6 +59,7 @@ import co.yml.charts.ui.linechart.model.LineType
 import co.yml.charts.ui.linechart.model.SelectionHighlightPoint
 import co.yml.charts.ui.linechart.model.SelectionHighlightPopUp
 import kotlinx.coroutines.launch
+import kotlin.math.pow
 
 /**
  *

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
         classpath(versionCatalogLibs.android.gradle.plugin)
         classpath(versionCatalogLibs.kotlin.gradle.plugin)
-        classpath("org.jetbrains.kotlin:kotlin-android-extensions:1.8.20")
+        classpath("org.jetbrains.kotlin:kotlin-android-extensions:1.9.23")
     }
 
     tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
         classpath(versionCatalogLibs.android.gradle.plugin)
         classpath(versionCatalogLibs.kotlin.gradle.plugin)
-        classpath("org.jetbrains.kotlin:kotlin-android-extensions:1.9.23")
+        classpath("org.jetbrains.kotlin:kotlin-android-extensions:2.2.0")
     }
 
     tasks {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,47 +2,47 @@
 # Define the dependency versions
 #Project
 #kotlin
-kotlinVersion = "1.8.20"
+kotlinVersion = "1.9.21"
 kotlinxSerializationJson = "1.5.0"
 #gradle
 androidGradlePlugin = "8.0.2"
 
 #Modules
 #androidx
-androidxComposeBom = "2023.05.01"
-androidxActivityCompose = "1.7.0"
-androidxAppCompat = "1.6.1"
-androidxComposeCompiler = "1.4.6"
-androidxCore = "1.9.0"
-androidxLifecycle = "2.6.1"
-androidxNavigation = "2.5.3"
-androidxEspresso = "3.5.1"
-androidxTestRules = "1.5.0"
-androidxTestRunner = "1.5.2"
-androidxTestMonitor = "1.6.1"
-androidxTestCore = "1.5.0"
-androidxTestExt = "1.1.5"
+androidxComposeBom = "2024.12.01"
+androidxActivityCompose = "1.9.3"
+androidxAppCompat = "1.7.0"
+androidxComposeCompiler = "1.5.7"
+androidxCore = "1.15.0"
+androidxLifecycle = "2.8.7"
+androidxNavigation = "2.8.5"
+androidxEspresso = "3.6.1"
+androidxTestRules = "1.6.1"
+androidxTestRunner = "1.6.2"
+androidxTestMonitor = "1.7.2"
+androidxTestCore = "1.6.1"
+androidxTestExt = "1.2.1"
 androidxCrypto = "1.1.0-alpha04"
 androidxDatastore = "1.0.0"
 
 #compose
-compose_ui = "1.4.3"
-compose_ui_testing = "1.4.3"
+compose_ui = "1.7.6"
+compose_ui_testing = "1.7.6"
 compose_constraint_layout = "1.1.0-alpha05"
 #ktx
-core_ktx = "1.9.0"
+core_ktx = "1.15.0"
 #coroutine
-coroutine = "1.7.1"
+coroutine = "1.8.1"
 turbine = "1.0.0"
 #android test
 junit4 = "4.13.2"
-android_junit = "1.1.5"
+android_junit = "1.2.1"
 espresso = "3.5.0"
 jupiter_junit = "5.9.2"
 #Mock
-anotation = "1.6.0"
+anotation = "1.9.1"
 mockk_android = "1.13.4"
-test_runner = "1.5.2"
+test_runner = "1.6.2"
 #sonar
 sonar = "4.0.0.2929"
 #dokka


### PR DESCRIPTION
## :loudspeaker: Type of change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

## :scroll: Description
Modified LineChart to use the Advanced Cubic Bezier algorithm for line smoothening as given at [https://medium.com/mobile-app-development-publication/making-graph-plotting-function-in-jetpack-compose-95c80ee6fc7f](https://medium.com/mobile-app-development-publication/making-graph-plotting-function-in-jetpack-compose-95c80ee6fc7f)

## :bulb: Motivation and Context
The default line chart has a 'staggered' look which is not found in libs like chart.js or SwiftUI charts, so I searched for ways to improve the smoothening algorithm and found the mentioned article, and tried it out.

## :green_heart: How did you test it?
Using the library with the modified file in an Android project as module dependency and tested both on emulator and device

## :pencil: Checklist

- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [x] All linters passing
- [ ] There are no code climate issues

## :camera_flash: Screenshots / GIFs
![Basic Cubic Bezier](https://github.com/codeandtheory/YCharts/assets/6216877/12a086eb-3fe0-43e2-b9ed-2e1dafbab8ad)
Basic Cubic Bezier

![Advancd Cubic Bezier](https://github.com/codeandtheory/YCharts/assets/6216877/f9bf3760-ca16-4644-8abc-b1326d28b8d3)
Advance Cubic Bezier


# Validation
Run the sample app and check the difference in the Line Charts 

# Risks
It is computationally more expensive than the basic cubic Bezier
