### PR TITLE
Add Background Transparency to DonutPieChart.kt

### DIFF
--- a/YChartsLib/src/main/java/co/yml/charts/ui/piechart/charts/DonutPieChart.kt
+++ b/YChartsLib/src/main/java/co/yml/charts/ui/piechart/charts/DonutPieChart.kt
@@ -98,7 +98,8 @@ fun DonutPieChart(
         }
     }
     Surface(
-        modifier = modifier
+        modifier = modifier,
+        color = Color.Transparent
     ) {
         val boxModifier = if (pieChartConfig.isClickOnSliceEnabled) {
             modifier


### PR DESCRIPTION
# Description
 This makes it possible to make pie charts transparent.  

# Validation
Try making the pie chart transparent with previous version and try making it transparent with this change. 

# Risks
No risks at all, only changed one line of code to allow for transparency. If you are still alive or even care about this project a little please merge this simple change.  
