### PR TITLE
Fix padding issue to prevent the first label and point being cut in a…

### DIFF
--- a/YChartsLib/src/main/java/co/yml/charts/ui/linechart/LineChart.kt
+++ b/YChartsLib/src/main/java/co/yml/charts/ui/linechart/LineChart.kt
@@ -144,12 +144,7 @@ fun LineChart(modifier: Modifier, lineChartData: LineChartData) {
                             .align(Alignment.BottomStart)
                             .onGloballyPositioned {
                                 rowHeight = it.size.height.toFloat()
-                            }
-                            .clip(
-                                RowClip(
-                                    columnWidth, paddingRight
-                                )
-                            ),
+                            },
                         xStart = columnWidth,
                         scrollOffset = scrollOffset,
                         zoomScale = xZoom,


### PR DESCRIPTION
… line chart

# Related Tickets
Fixes [#171](https://github.com/codeandtheory/YCharts/issues/171)

# Description
Fixes the issue related to the first label on x-axis, which was not visible fully in LineChart. 

# Validation
![Screenshot_1731007918](https://github.com/user-attachments/assets/54ada3c3-6ae5-4d46-9c12-f533bbfa1528)

